### PR TITLE
Move sim repos to rmf-simulation image

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,13 @@
-[![.github/workflows/docker-image.yml](https://github.com/open-rmf/rmf_deployment_template/actions/workflows/docker-image.yml/badge.svg)](https://github.com/open-rmf/rmf_deployment_template/actions/workflows/docker-image.yml)
+![](https://github.com/open-rmf/rmf_deployment_template/workflows/Docker%20Image%20CI/badge.svg)
+![](https://github.com/open-rmf/rmf_deployment_template/workflows/rmf-site-ci/badge.svg)
 
 # RMF Deployment Template
 This repo provides a sample template to build, deploy and manage an RMF installation (i.e. GitOps for RMF)
 
 This repo is structured as -
 - `main` - Contains Dockerfiles and CI pipeline to build images for this example deployment
-- `build/rmf-site` - Contains example rmf-site related resources, dockerfiles and CI process
-- `cloud_infra` - Cloud cluster bringup scripts, resources and runtime configs
+- [build/rmf-site](https://github.com/open-rmf/rmf_deployment_template/tree/build/rmf-site) - Contains example rmf-site related resources, dockerfiles and CI process
+- [cloud_infra](https://github.com/open-rmf/rmf_deployment_template/tree/cloud_infra) - Cloud cluster bringup scripts, resources and runtime configs
 
 _(These branches may be setup as independant repos for a production environment, the intent in having them as branches here is to provide a concise one-stop location for easy reference.)_
 

--- a/rmf-simulation/rmf-simulation.repos
+++ b/rmf-simulation/rmf-simulation.repos
@@ -1,5 +1,13 @@
 repositories:
+  rmf/rmf_simulation:
+    type: git
+    url: https://github.com/open-rmf/rmf_simulation.git
+    version: main
   rmf/rmf_demos:
     type: git
     url: https://github.com/open-rmf/rmf_demos.git
     version: main
+  thirdparty/menge_vendor:
+    type: git
+    url: https://github.com/open-rmf/menge_vendor.git
+    version: master

--- a/rmf/rmf.repos
+++ b/rmf/rmf.repos
@@ -23,10 +23,6 @@ repositories:
     type: git
     url: https://github.com/open-rmf/rmf_ros2
     version: main
-  rmf/rmf_simulation:
-    type: git
-    url: https://github.com/open-rmf/rmf_simulation.git
-    version: main
   rmf/rmf_task:
     type: git
     url: https://github.com/open-rmf/rmf_task.git
@@ -51,10 +47,6 @@ repositories:
     type: git
     url: https://github.com/open-rmf/rmf_visualization_msgs.git
     version: main
-  thirdparty/menge_vendor:
-    type: git
-    url: https://github.com/open-rmf/menge_vendor.git
-    version: master
   thirdparty/nlohmann_json_schema_validator_vendor:
     type: git
     url: https://github.com/open-rmf/nlohmann_json_schema_validator_vendor.git


### PR DESCRIPTION
Reorg pkgs in rmf docker images. Move all simulation related pkgs to downstream `rmf-simulation` img