### PR TITLE
Move cloud infra bringup scripts and instructions to main

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,13 @@
 This repo provides a sample template to build, deploy and manage an RMF installation (i.e. GitOps for RMF)
 
 This repo is structured as -
-- `main` - Contains Dockerfiles and CI pipeline to build images for this example deployment
+- `main` - Contains Dockerfiles & CI pipeline to build images, and cloud infra instructions. 
+  - `rmf`: dockerfiles for base rmf images
+  - `rmf-simulation`: dockerfiles for rmf with simulation, built with base rmf image
+  - `rmf-web`: dockerfiles for rmf web application, build with base rmf image
+  - `infrastructure`: Cloud cluster bringup scripts and [README](infrastructure/README.md)
 - `build/rmf-site` - Contains example rmf-site related resources, dockerfiles and CI process
-- `cloud_infra` - Cloud cluster bringup scripts, resources and runtime configs
+- `cloud_infra` - `rmf_deployment` app template for deploying rmf application to cloud
 
 _(These branches may be setup as independant repos for a production environment, the intent in having them as branches here is to provide a concise one-stop location for easy reference.)_
 

--- a/infrastructure/README.md
+++ b/infrastructure/README.md
@@ -1,0 +1,86 @@
+# Infrastructure
+
+This directory contains the bringup instructions and configurations to setup a Kubernetes cluster infrastructure.
+
+The app to deploy is located in `cloud_infra` as `rmf_deployment`. The `rmf_deployment` template is fully configurable and minimally will need following edits prior to bringup. Be sure to edit these prior to running thru the next steps..
+- RMF configuration in `rmf-deployment/`
+    - `rmf_server_config.py` - replace DNS name `rmf-deployment-template.open-rmf.org` with your own.
+    - `values.yaml` - replace registryUrl `ghcr.io/open-rmf` and DNS name `rmf-deployment-template.open-rmf.org` with your own.
+    - `cyclonedds.xml` - if you are using cyclonedds to communicate across multiple nodes on different machines, update the `Peers` in the `.xml`.
+    - `rmf-site-modules.yaml` - Add site specific nodes (e.g. fleet and door adapters) to the template.
+
+## Provisioning
+We will need the following resources:
+* 1 Cloud VM ( For RMF k8s cluster )
+* Operator Machine ( For provisioning ) with SSH access to this VM.
+
+### Cloud resource provisioning
+
+#### Provision Cloud VM
+VM specifications:
+- 4 vCPU, 8GB memory _[recommended size for 2 robots, 1 door, 1 lift (elevator), your mileage may vary based on your scale]_
+- 80GB SSD storage
+- 1 public IP
+- Ports 443, 22 open
+
+#### Add DNS record
+Add VM public IP to domain url in DNS records (eg. Route 53 in AWS)
+
+### Bootstrap Kubernetes Cluster on Cloud Machine
+K8s will only run on the single deployment node
+```bash
+curl -fsSL get.docker.com -o get-docker.sh && sh get-docker.sh
+
+curl -sLS https://get.k3sup.dev | sh
+sudo install k3sup /usr/local/bin/
+k3sup install --local --user ubuntu --cluster --k3s-extra-args '--flannel-iface=ens5 --no-deploy traefik --write-kubeconfig-mode --docker'
+
+git clone git@github.com:open-rmf/rmf_deployment_template.git
+cd rmf_deployment_template
+
+kubectl apply -f infrastructure/nginx/ingress-nginx.yaml
+kubectl wait --for=condition=available deployment/ingress-nginx-controller -n ingress-nginx --timeout=2m
+
+# Get ingress IP
+kubectl get svc ingress-nginx-controller -n ingress-nginx -o jsonpath="{.status.loadBalancer.ingress[0].ip}"
+# Get the Node-Pod mapping
+kubectl get pod -o=custom-columns=NAME:.metadata.name,STATUS:.status.phase,NODE:.spec.nodeName --all-namespaces
+```
+
+### Set up SSL Certificates
+```bash
+kubectl create namespace cert-manager
+kubectl apply -f https://github.com/jetstack/cert-manager/releases/latest/download/cert-manager.yaml
+kubectl wait --for=condition=available deployment/cert-manager -n cert-manager --timeout=2m
+
+# NOTE: Specify your `ACME_EMAIL` and `DOMAIN_NAME` for letsencrypt-issuer-production
+export DOMAIN_NAME=rmf-deployment-template.open-rmf.org
+export ACME_EMAIL=YOUREMAIL@DOMAIN.com
+envsubst < infrastructure/cert-manager/letsencrypt-issuer-production.yaml | kubectl apply -f -
+kubectl get certificates # should be true, might need to wait a minute
+```
+
+### Continuous Deployment: ArgoCD
+We will use ArgoCD to handle infra changes to the `cloud_infra` branch of this repository. The `rmf_deployment` directory consists of all nessarry helm charts needed for rmf deployment
+
+```bash
+kubectl create namespace argocd
+kubectl apply -n argocd -f https://raw.githubusercontent.com/argoproj/argo-cd/stable/manifests/install.yaml
+kubectl create namespace deploy
+kubectl port-forward svc/argocd-server -n argocd 9090:443
+# Start a new ssh session with port forward 9090 to the VM, you should now be able to view the admin panel on port localhost:9090
+
+# Get the initial password
+kubectl -n argocd get secret argocd-initial-admin-secret -o jsonpath="{.data.password}" | base64 -d
+
+# Connect the repository
+## View the docs to learn how to configure ArgoCD
+## When adding a "new app" on argocd, we will specify the repo, `cloud_infra` branch and `rmf_deployment` dir 
+
+# Now if you sync the app, we should see the full deployment "come alive"
+
+# Add domain url and initial credentials (after keycloak pod is running)
+./keycloak-setup.bash rmf-deployment-template.open-rmf.org 
+```
+
+RMF web dashboard will now be accessible on your_url/dashboard (eg. rmf.open-rmf.org/dashboard); users can be manage via your_url/auth (eg. rmf.open-rmf.org/auth)

--- a/infrastructure/cert-manager/letsencrypt-issuer-production.yaml
+++ b/infrastructure/cert-manager/letsencrypt-issuer-production.yaml
@@ -1,0 +1,34 @@
+---
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: letsencrypt-prod
+spec:
+  acme:
+    # The ACME server URL
+    server: https://acme-v02.api.letsencrypt.org/directory
+    # Email address used for ACME registration
+    email: $ACME_EMAIL
+    # Name of a secret used to store the ACME account private key
+    privateKeySecretRef:
+      name: letsencrypt-prod
+    # Enable the HTTP-01 challenge provider
+    solvers:
+      - http01:
+          ingress:
+            class: nginx
+
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: tls-certificate-secret-name
+  namespace: default
+spec:
+  secretName: tls-certificate-secret-name
+  issuerRef:
+    name: letsencrypt-prod
+    kind: ClusterIssuer
+  commonName: $DOMAIN_NAME
+  dnsNames:
+    - $DOMAIN_NAME

--- a/infrastructure/keycloak-setup.bash
+++ b/infrastructure/keycloak-setup.bash
@@ -1,0 +1,258 @@
+#!/bin/bash
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+export PROJECT=keycloak-setup
+SCRIPTPATH="$(
+    cd -- "$(dirname "$0")" >/dev/null 2>&1
+    pwd -P
+)"
+
+. "$SCRIPTPATH/utils.bash"
+
+: "${KEYCLOAK_ADMIN:=admin}"
+: "${KEYCLOAK_ADMIN_PASSWD:=admin123}"
+: "${ROOT_URL:=https://$1}"
+KEYCLOAK_BASE_URL=$ROOT_URL/auth
+TOKEN_WORKSPACE="deploy"
+MASTER_TOKEN_URL="$KEYCLOAK_BASE_URL/realms/master/protocol/openid-connect/token"
+REALM_URL="$KEYCLOAK_BASE_URL/$KEYCLOAK_ADMIN/realms"
+REALM_CLIENT_URL="$REALM_URL/rmf-web/clients"
+REALM_USERS_URL="$REALM_URL/rmf-web/users"
+REALM_EVENTS_URL="$REALM_URL/rmf-web/events"
+REALM_CLIENT_SCOPES_URL="$REALM_URL/rmf-web/client-scopes"
+
+command -v jq >>/dev/null || { __msg_info "Install jq dependency.." && sudo apt install jq; }
+
+__msg_info "Retrieving JWT Token"
+
+TOKEN_REQUEST_RESPONSE=$(
+    curl -k -s -X POST \
+        -H "Content-Type: application/x-www-form-urlencoded" \
+        -d "username=$KEYCLOAK_ADMIN" \
+        -d "password=$KEYCLOAK_ADMIN_PASSWD" \
+        -d "grant_type=password" \
+        -d "client_id=admin-cli" \
+        "$MASTER_TOKEN_URL" |
+        jq -r '.access_token'
+) || __error_exit $LINENO "Is Keycloak up?"
+
+
+[ "$TOKEN_REQUEST_RESPONSE" != "null" ] || __error_exit $LINENO "Something went wrong retrieving JWT Token. Check credentials"
+
+__msg_info "Creating Realm rmf-web"
+REALM_CREATION_RESPONSE=$(curl -k -s -X POST \
+    -H "Content-Type: application/json" \
+    -H "Authorization: Bearer $TOKEN_REQUEST_RESPONSE" \
+    -d '{"id":"rmf-web","realm":"rmf-web","enabled":"true"}' \
+    "$REALM_URL")
+
+__msg_debug "$REALM_CREATION_RESPONSE"
+
+__msg_info "Creating Clients."
+DASHBOARD_CLIENT_REQUEST_JSON=$(
+    jq -n \
+        --arg rootUrl "$ROOT_URL" \
+        --arg redirectRootUrl "$ROOT_URL/*" \
+        '{"clientId":"dashboard","rootUrl":$rootUrl,"redirectUris":[$redirectRootUrl],"webOrigins":[$rootUrl],publicClient:"true"}'
+)
+
+CLIENT_DASHBOARD_CREATION_RESPONSE=$(curl -k -s -X POST \
+    -H "Content-Type: application/json" \
+    -H "Authorization: Bearer $TOKEN_REQUEST_RESPONSE" \
+    -d "$DASHBOARD_CLIENT_REQUEST_JSON" \
+    "$REALM_CLIENT_URL")
+
+__msg_debug "$CLIENT_DASHBOARD_CREATION_RESPONSE"
+
+REPORTING_CLIENT_REQUEST_JSON=$(
+    jq -n \
+        --arg rootUrl "$ROOT_URL" \
+        --arg redirectRootUrl "$ROOT_URL/*" \
+        '{"clientId":"reporting","rootUrl":$rootUrl,"redirectUris":[$redirectRootUrl],"webOrigins":[$rootUrl],publicClient:"true"}'
+)
+
+CLIENT_REPORTING_CREATION_RESPONSE=$(curl -k -s -X POST \
+    -H "Content-Type: application/json" \
+    -H "Authorization: Bearer $TOKEN_REQUEST_RESPONSE" \
+    -d "$REPORTING_CLIENT_REQUEST_JSON" \
+    "$REALM_CLIENT_URL")
+
+__msg_debug "$CLIENT_REPORTING_CREATION_RESPONSE"
+
+ADMIN_USER_ID=$(curl -k -s -X GET \
+    -H "Content-Type: application/json" \
+    -H "Authorization: Bearer $TOKEN_REQUEST_RESPONSE" \
+    "$REALM_USERS_URL?username=admin" | jq -r ".[0].id") 
+
+if [ "$ADMIN_USER_ID" != "null" ]; then
+    __msg_debug "admin user already created. Skipping."
+else
+    __msg_info "Creating Admin User."
+    ADMIN_USER_CREATION_RESPONSE=$(curl -k -s -X POST \
+        -H "Content-Type: application/json" \
+        -H "Authorization: Bearer $TOKEN_REQUEST_RESPONSE" \
+        -d '{"username":"admin","enabled":"true"}' \
+        "$REALM_USERS_URL")
+    __msg_debug "$ADMIN_USER_CREATION_RESPONSE"
+
+    ADMIN_USER_ID=$(curl -k -s -X GET \
+        -H "content-type: application/json" \
+        -H "authorization: bearer $TOKEN_REQUEST_RESPONSE" \
+        "$REALM_USERS_URL?username=admin" | jq -r '.[0].id')
+
+    curl -k -s -X PUT \
+        -H "Content-Type: application/json" \
+        -H "Authorization: Bearer $TOKEN_REQUEST_RESPONSE" \
+        -d '{"value": "admin", "temporary": "false"}' \
+        "$REALM_USERS_URL/$ADMIN_USER_ID/reset-password" || __error_exit $LINENO "Something went wrong resetting admin password."
+    __msg_info "Admin user created with password 'admin'"
+fi
+
+EXAMPLE_USER_ID=$(curl -k -s -X GET \
+    -H "Content-Type: application/json" \
+    -H "Authorization: Bearer $TOKEN_REQUEST_RESPONSE" \
+    "$REALM_USERS_URL?username=example" | jq -r ".[0].id") 
+
+if [ "$EXAMPLE_USER_ID" != "null" ]; then
+    __msg_debug "example user already created. Skipping."
+else
+    __msg_info "Creating example User."
+    EXAMPLE_USER_CREATION_RESPONSE=$(curl -k -s -X POST \
+        -H "Content-Type: application/json" \
+        -H "Authorization: Bearer $TOKEN_REQUEST_RESPONSE" \
+        -d '{"username":"example","enabled":"true"}' \
+        "$REALM_USERS_URL")
+    __msg_debug "$EXAMPLE_USER_CREATION_RESPONSE"
+
+    EXAMPLE_USER_ID=$(curl -k -s -X GET \
+        -H "content-type: application/json" \
+        -H "authorization: bearer $TOKEN_REQUEST_RESPONSE" \
+        "$REALM_USERS_URL?username=example" | jq -r '.[0].id')
+
+    curl -k -s -X PUT \
+        -H "Content-Type: application/json" \
+        -H "Authorization: Bearer $TOKEN_REQUEST_RESPONSE" \
+        -d '{"value": "example", "temporary": "false"}' \
+        "$REALM_USERS_URL/$EXAMPLE_USER_ID/reset-password" || __error_exit $LINENO "Something went wrong resetting example user password."
+    __msg_info "example user created with password 'example'"
+fi
+
+curl -k -s -X PUT \
+    -H "Content-Type: application/json" \
+    -H "Authorization: Bearer $TOKEN_REQUEST_RESPONSE" \
+    -d '{"eventsEnabled": "true", "eventsListeners": ["jsonlog_event_listener"]}' \
+    "$REALM_EVENTS_URL/config" 
+
+__msg_info "Creating Client Scopes."
+DASHBOARD_CLIENT_SCOPE_CREATION_RESPONSE=$(curl -k -s -X POST \
+    -H "Content-Type: application/json" \
+    -H "Authorization: Bearer $TOKEN_REQUEST_RESPONSE" \
+    --data-binary @- << EOF "$REALM_CLIENT_SCOPES_URL"
+{
+  "name": "dashboard",
+  "protocol": "openid-connect",
+  "description": "dashboard scope",
+  "protocolMappers": [
+    {
+      "name": "rmf-audience",
+      "protocol": "openid-connect",
+      "protocolMapper": "oidc-audience-mapper",
+      "config": {
+        "access.token.claim": "true",
+        "id.token.claim": "false",
+        "included.client.audience": "dashboard"
+      }
+    }
+  ]
+}
+EOF
+)
+
+__msg_debug "$DASHBOARD_CLIENT_SCOPE_CREATION_RESPONSE"
+
+REPORTING_CLIENT_SCOPE_CREATION_RESPONSE=$(curl -k -s -X POST \
+    -H "Content-Type: application/json" \
+    -H "Authorization: Bearer $TOKEN_REQUEST_RESPONSE" \
+    --data-binary @- << EOF "$REALM_CLIENT_SCOPES_URL"
+{
+  "name": "reporting",
+  "protocol": "openid-connect",
+  "description": "reporting scope",
+  "protocolMappers": [
+    {
+      "name": "rmf-audience",
+      "protocol": "openid-connect",
+      "protocolMapper": "oidc-audience-mapper",
+      "config": {
+        "access.token.claim": "true",
+        "id.token.claim": "false",
+        "included.client.audience": "reporting"
+      }
+    }
+  ]
+}
+EOF
+)
+
+__msg_debug "$REPORTING_CLIENT_SCOPE_CREATION_RESPONSE"
+
+__msg_info "Linking up Client Scopes and Clients."
+ALL_CLIENTS_JSON=$(curl -k -s -X GET \
+    -H "Content-Type: application/json" \
+    -H "Authorization: Bearer $TOKEN_REQUEST_RESPONSE" \
+    "$REALM_CLIENT_URL") 
+
+DASHBOARD_CLIENT_ID=$(echo "$ALL_CLIENTS_JSON" | jq -r '.[] | select ( .clientId == "dashboard" )' | jq -r '.id')
+REPORTING_CLIENT_ID=$(echo "$ALL_CLIENTS_JSON" | jq -r '.[] | select ( .clientId == "reporting" )' | jq -r '.id')
+
+ALL_CLIENT_SCOPES_JSON=$(curl -k -s -X GET \
+    -H "Content-Type: application/json" \
+    -H "Authorization: Bearer $TOKEN_REQUEST_RESPONSE" \
+    "$REALM_CLIENT_SCOPES_URL") 
+
+DASHBOARD_CLIENT_SCOPES_ID=$(echo "$ALL_CLIENT_SCOPES_JSON" | jq -r '.[] | select ( .name == "dashboard" )' | jq -r '.id')
+REPORTING_CLIENT_SCOPES_ID=$(echo "$ALL_CLIENT_SCOPES_JSON" | jq -r '.[] | select ( .name == "reporting" )' | jq -r '.id')
+
+[ -n "$DASHBOARD_CLIENT_SCOPES_ID" ] || __error_exit $LINENO "Something went wrong retrieving the dashboard client id."
+[ -n "$REPORTING_CLIENT_SCOPES_ID" ] || __error_exit $LINENO "Something went wrong retrieving the reporting client id."
+
+curl -k -s -X PUT \
+    -H "Content-Type: application/json" \
+    -H "Authorization: Bearer $TOKEN_REQUEST_RESPONSE" \
+    -d '{"value": "admin", "temporary": "false"}' \
+    "$REALM_CLIENT_URL/$DASHBOARD_CLIENT_ID/default-client-scopes/$DASHBOARD_CLIENT_SCOPES_ID" || \
+        __error_exit $LINENO "Something went wrong assigning the dashboard client scope."
+
+curl -k -s -X PUT \
+    -H "Content-Type: application/json" \
+    -H "Authorization: Bearer $TOKEN_REQUEST_RESPONSE" \
+    -d '{"value": "admin", "temporary": "false"}' \
+    "$REALM_CLIENT_URL/$REPORTING_CLIENT_ID/default-client-scopes/$REPORTING_CLIENT_SCOPES_ID" || \
+        __error_exit $LINENO "Something went wrong assigning the reporting client scope."
+
+JWKS_URI=$(curl -k -s -X GET \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer $TOKEN_REQUEST_RESPONSE" \
+  "$KEYCLOAK_BASE_URL/realms/rmf-web/.well-known/openid-configuration" | jq -r '.jwks_uri')
+
+JWKS_X5C=$(curl -k -s -X GET \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer $TOKEN_REQUEST_RESPONSE" \
+  "$JWKS_URI" | jq -r '.keys[0].x5c[0]')
+
+[ -n "$JWKS_X5C" ] || __error_exit $LINENO "Something went wrong trying to retrieve Certificate."
+
+PEM_FILE="-----BEGIN CERTIFICATE-----
+$JWKS_X5C
+-----END CERTIFICATE-----"
+echo "$PEM_FILE" > /tmp/cert.pem
+openssl x509 -pubkey -noout -in /tmp/cert.pem  > /tmp/jwt-pub-key.pub
+
+echo "jwt-pub-key"
+echo /tmp/jwt-pub-key.pub
+
+echo "uploading pubkey to kubernetes, may not be necessary if you are not using k8s"
+kubectl create configmap jwt-pub-key --from-file=/tmp/jwt-pub-key.pub -o=yaml --dry-run=client | kubectl apply -n $TOKEN_WORKSPACE -f -

--- a/infrastructure/nginx/ingress-nginx.yaml
+++ b/infrastructure/nginx/ingress-nginx.yaml
@@ -1,0 +1,679 @@
+
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: ingress-nginx
+  labels:
+    app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/instance: ingress-nginx
+
+---
+# Source: ingress-nginx/templates/controller-serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    helm.sh/chart: ingress-nginx-4.0.1
+    app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/instance: ingress-nginx
+    app.kubernetes.io/version: 1.0.0
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: controller
+  name: ingress-nginx
+  namespace: ingress-nginx
+automountServiceAccountToken: true
+---
+# Source: ingress-nginx/templates/controller-configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  labels:
+    helm.sh/chart: ingress-nginx-4.0.1
+    app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/instance: ingress-nginx
+    app.kubernetes.io/version: 1.0.0
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: controller
+  name: ingress-nginx-controller
+  namespace: ingress-nginx
+data:
+  compute-full-forwarded-for: "true"
+  use-forwarded-headers: "true"
+  real-ip-header: proxy_protocol
+---
+# Source: ingress-nginx/templates/clusterrole.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    helm.sh/chart: ingress-nginx-4.0.1
+    app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/instance: ingress-nginx
+    app.kubernetes.io/version: 1.0.0
+    app.kubernetes.io/managed-by: Helm
+  name: ingress-nginx
+rules:
+  - apiGroups:
+      - ''
+    resources:
+      - configmaps
+      - endpoints
+      - nodes
+      - pods
+      - secrets
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+      - ''
+    resources:
+      - nodes
+    verbs:
+      - get
+  - apiGroups:
+      - ''
+    resources:
+      - services
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - networking.k8s.io
+    resources:
+      - ingresses
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - ''
+    resources:
+      - events
+    verbs:
+      - create
+      - patch
+  - apiGroups:
+      - networking.k8s.io
+    resources:
+      - ingresses/status
+    verbs:
+      - update
+  - apiGroups:
+      - networking.k8s.io
+    resources:
+      - ingressclasses
+    verbs:
+      - get
+      - list
+      - watch
+---
+# Source: ingress-nginx/templates/clusterrolebinding.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    helm.sh/chart: ingress-nginx-4.0.1
+    app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/instance: ingress-nginx
+    app.kubernetes.io/version: 1.0.0
+    app.kubernetes.io/managed-by: Helm
+  name: ingress-nginx
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: ingress-nginx
+subjects:
+  - kind: ServiceAccount
+    name: ingress-nginx
+    namespace: ingress-nginx
+---
+# Source: ingress-nginx/templates/controller-role.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  labels:
+    helm.sh/chart: ingress-nginx-4.0.1
+    app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/instance: ingress-nginx
+    app.kubernetes.io/version: 1.0.0
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: controller
+  name: ingress-nginx
+  namespace: ingress-nginx
+rules:
+  - apiGroups:
+      - ''
+    resources:
+      - namespaces
+    verbs:
+      - get
+  - apiGroups:
+      - ''
+    resources:
+      - configmaps
+      - pods
+      - secrets
+      - endpoints
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - ''
+    resources:
+      - services
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - networking.k8s.io
+    resources:
+      - ingresses
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - networking.k8s.io
+    resources:
+      - ingresses/status
+    verbs:
+      - update
+  - apiGroups:
+      - networking.k8s.io
+    resources:
+      - ingressclasses
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - ''
+    resources:
+      - configmaps
+    resourceNames:
+      - ingress-controller-leader
+    verbs:
+      - get
+      - update
+  - apiGroups:
+      - ''
+    resources:
+      - configmaps
+    verbs:
+      - create
+  - apiGroups:
+      - ''
+    resources:
+      - events
+    verbs:
+      - create
+      - patch
+---
+# Source: ingress-nginx/templates/controller-rolebinding.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  labels:
+    helm.sh/chart: ingress-nginx-4.0.1
+    app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/instance: ingress-nginx
+    app.kubernetes.io/version: 1.0.0
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: controller
+  name: ingress-nginx
+  namespace: ingress-nginx
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: ingress-nginx
+subjects:
+  - kind: ServiceAccount
+    name: ingress-nginx
+    namespace: ingress-nginx
+---
+# Source: ingress-nginx/templates/controller-service-webhook.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    helm.sh/chart: ingress-nginx-4.0.1
+    app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/instance: ingress-nginx
+    app.kubernetes.io/version: 1.0.0
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: controller
+  name: ingress-nginx-controller-admission
+  namespace: ingress-nginx
+spec:
+  type: ClusterIP
+  ports:
+    - name: https-webhook
+      port: 443
+      targetPort: webhook
+      appProtocol: https
+  selector:
+    app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/instance: ingress-nginx
+    app.kubernetes.io/component: controller
+---
+# Source: ingress-nginx/templates/controller-service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+  labels:
+    helm.sh/chart: ingress-nginx-4.0.1
+    app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/instance: ingress-nginx
+    app.kubernetes.io/version: 1.0.0
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: controller
+  name: ingress-nginx-controller
+  namespace: ingress-nginx
+spec:
+  type: LoadBalancer
+  externalTrafficPolicy: Local
+  ports:
+    - name: http
+      port: 80
+      protocol: TCP
+      targetPort: http
+      appProtocol: http
+    - name: https
+      port: 443
+      protocol: TCP
+      targetPort: https
+      appProtocol: https
+  selector:
+    app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/instance: ingress-nginx
+    app.kubernetes.io/component: controller
+---
+# Source: ingress-nginx/templates/controller-deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    helm.sh/chart: ingress-nginx-4.0.1
+    app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/instance: ingress-nginx
+    app.kubernetes.io/version: 1.0.0
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: controller
+  name: ingress-nginx-controller
+  namespace: ingress-nginx
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: ingress-nginx
+      app.kubernetes.io/instance: ingress-nginx
+      app.kubernetes.io/component: controller
+  revisionHistoryLimit: 10
+  minReadySeconds: 0
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: ingress-nginx
+        app.kubernetes.io/instance: ingress-nginx
+        app.kubernetes.io/component: controller
+    spec:
+      dnsPolicy: ClusterFirst
+      containers:
+        - name: controller
+          image: k8s.gcr.io/ingress-nginx/controller:v1.0.0@sha256:0851b34f69f69352bf168e6ccf30e1e20714a264ab1ecd1933e4d8c0fc3215c6
+          imagePullPolicy: IfNotPresent
+          lifecycle:
+            preStop:
+              exec:
+                command:
+                  - /wait-shutdown
+          args:
+            - /nginx-ingress-controller
+            - --publish-service=$(POD_NAMESPACE)/ingress-nginx-controller
+            - --election-id=ingress-controller-leader
+            - --controller-class=k8s.io/ingress-nginx
+            - --configmap=$(POD_NAMESPACE)/ingress-nginx-controller
+            - --validating-webhook=:8443
+            - --validating-webhook-certificate=/usr/local/certificates/cert
+            - --validating-webhook-key=/usr/local/certificates/key
+          securityContext:
+            capabilities:
+              drop:
+                - ALL
+              add:
+                - NET_BIND_SERVICE
+            runAsUser: 101
+            allowPrivilegeEscalation: true
+          env:
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: LD_PRELOAD
+              value: /usr/local/lib/libmimalloc.so
+          livenessProbe:
+            failureThreshold: 5
+            httpGet:
+              path: /healthz
+              port: 10254
+              scheme: HTTP
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
+          readinessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: /healthz
+              port: 10254
+              scheme: HTTP
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
+          ports:
+            - name: http
+              containerPort: 80
+              protocol: TCP
+            - name: https
+              containerPort: 443
+              protocol: TCP
+            - name: webhook
+              containerPort: 8443
+              protocol: TCP
+          volumeMounts:
+            - name: webhook-cert
+              mountPath: /usr/local/certificates/
+              readOnly: true
+          resources:
+            requests:
+              cpu: 100m
+              memory: 90Mi
+      nodeSelector:
+        kubernetes.io/os: linux
+      serviceAccountName: ingress-nginx
+      terminationGracePeriodSeconds: 300
+      volumes:
+        - name: webhook-cert
+          secret:
+            secretName: ingress-nginx-admission
+---
+# Source: ingress-nginx/templates/controller-ingressclass.yaml
+# We don't support namespaced ingressClass yet
+# So a ClusterRole and a ClusterRoleBinding is required
+apiVersion: networking.k8s.io/v1
+kind: IngressClass
+metadata:
+  labels:
+    helm.sh/chart: ingress-nginx-4.0.1
+    app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/instance: ingress-nginx
+    app.kubernetes.io/version: 1.0.0
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: controller
+  name: nginx
+  namespace: ingress-nginx
+spec:
+  controller: k8s.io/ingress-nginx
+---
+# Source: ingress-nginx/templates/admission-webhooks/validating-webhook.yaml
+# before changing this value, check the required kubernetes version
+# https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/#prerequisites
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  labels:
+    helm.sh/chart: ingress-nginx-4.0.1
+    app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/instance: ingress-nginx
+    app.kubernetes.io/version: 1.0.0
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: admission-webhook
+  name: ingress-nginx-admission
+webhooks:
+  - name: validate.nginx.ingress.kubernetes.io
+    matchPolicy: Equivalent
+    rules:
+      - apiGroups:
+          - networking.k8s.io
+        apiVersions:
+          - v1
+        operations:
+          - CREATE
+          - UPDATE
+        resources:
+          - ingresses
+    failurePolicy: Fail
+    sideEffects: None
+    admissionReviewVersions:
+      - v1
+    clientConfig:
+      service:
+        namespace: ingress-nginx
+        name: ingress-nginx-controller-admission
+        path: /networking/v1/ingresses
+---
+# Source: ingress-nginx/templates/admission-webhooks/job-patch/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: ingress-nginx-admission
+  namespace: ingress-nginx
+  annotations:
+    helm.sh/hook: pre-install,pre-upgrade,post-install,post-upgrade
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+  labels:
+    helm.sh/chart: ingress-nginx-4.0.1
+    app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/instance: ingress-nginx
+    app.kubernetes.io/version: 1.0.0
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: admission-webhook
+---
+# Source: ingress-nginx/templates/admission-webhooks/job-patch/clusterrole.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: ingress-nginx-admission
+  annotations:
+    helm.sh/hook: pre-install,pre-upgrade,post-install,post-upgrade
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+  labels:
+    helm.sh/chart: ingress-nginx-4.0.1
+    app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/instance: ingress-nginx
+    app.kubernetes.io/version: 1.0.0
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: admission-webhook
+rules:
+  - apiGroups:
+      - admissionregistration.k8s.io
+    resources:
+      - validatingwebhookconfigurations
+    verbs:
+      - get
+      - update
+---
+# Source: ingress-nginx/templates/admission-webhooks/job-patch/clusterrolebinding.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: ingress-nginx-admission
+  annotations:
+    helm.sh/hook: pre-install,pre-upgrade,post-install,post-upgrade
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+  labels:
+    helm.sh/chart: ingress-nginx-4.0.1
+    app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/instance: ingress-nginx
+    app.kubernetes.io/version: 1.0.0
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: admission-webhook
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: ingress-nginx-admission
+subjects:
+  - kind: ServiceAccount
+    name: ingress-nginx-admission
+    namespace: ingress-nginx
+---
+# Source: ingress-nginx/templates/admission-webhooks/job-patch/role.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: ingress-nginx-admission
+  namespace: ingress-nginx
+  annotations:
+    helm.sh/hook: pre-install,pre-upgrade,post-install,post-upgrade
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+  labels:
+    helm.sh/chart: ingress-nginx-4.0.1
+    app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/instance: ingress-nginx
+    app.kubernetes.io/version: 1.0.0
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: admission-webhook
+rules:
+  - apiGroups:
+      - ''
+    resources:
+      - secrets
+    verbs:
+      - get
+      - create
+---
+# Source: ingress-nginx/templates/admission-webhooks/job-patch/rolebinding.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: ingress-nginx-admission
+  namespace: ingress-nginx
+  annotations:
+    helm.sh/hook: pre-install,pre-upgrade,post-install,post-upgrade
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+  labels:
+    helm.sh/chart: ingress-nginx-4.0.1
+    app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/instance: ingress-nginx
+    app.kubernetes.io/version: 1.0.0
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: admission-webhook
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: ingress-nginx-admission
+subjects:
+  - kind: ServiceAccount
+    name: ingress-nginx-admission
+    namespace: ingress-nginx
+---
+# Source: ingress-nginx/templates/admission-webhooks/job-patch/job-createSecret.yaml
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: ingress-nginx-admission-create
+  namespace: ingress-nginx
+  annotations:
+    helm.sh/hook: pre-install,pre-upgrade
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+  labels:
+    helm.sh/chart: ingress-nginx-4.0.1
+    app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/instance: ingress-nginx
+    app.kubernetes.io/version: 1.0.0
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: admission-webhook
+spec:
+  template:
+    metadata:
+      name: ingress-nginx-admission-create
+      labels:
+        helm.sh/chart: ingress-nginx-4.0.1
+        app.kubernetes.io/name: ingress-nginx
+        app.kubernetes.io/instance: ingress-nginx
+        app.kubernetes.io/version: 1.0.0
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/component: admission-webhook
+    spec:
+      containers:
+        - name: create
+          image: k8s.gcr.io/ingress-nginx/kube-webhook-certgen:v1.0@sha256:f3b6b39a6062328c095337b4cadcefd1612348fdd5190b1dcbcb9b9e90bd8068
+          imagePullPolicy: IfNotPresent
+          args:
+            - create
+            - --host=ingress-nginx-controller-admission,ingress-nginx-controller-admission.$(POD_NAMESPACE).svc
+            - --namespace=$(POD_NAMESPACE)
+            - --secret-name=ingress-nginx-admission
+          env:
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+      restartPolicy: OnFailure
+      serviceAccountName: ingress-nginx-admission
+      nodeSelector:
+        kubernetes.io/os: linux
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 2000
+---
+# Source: ingress-nginx/templates/admission-webhooks/job-patch/job-patchWebhook.yaml
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: ingress-nginx-admission-patch
+  namespace: ingress-nginx
+  annotations:
+    helm.sh/hook: post-install,post-upgrade
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+  labels:
+    helm.sh/chart: ingress-nginx-4.0.1
+    app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/instance: ingress-nginx
+    app.kubernetes.io/version: 1.0.0
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: admission-webhook
+spec:
+  template:
+    metadata:
+      name: ingress-nginx-admission-patch
+      labels:
+        helm.sh/chart: ingress-nginx-4.0.1
+        app.kubernetes.io/name: ingress-nginx
+        app.kubernetes.io/instance: ingress-nginx
+        app.kubernetes.io/version: 1.0.0
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/component: admission-webhook
+    spec:
+      containers:
+        - name: patch
+          image: k8s.gcr.io/ingress-nginx/kube-webhook-certgen:v1.0@sha256:f3b6b39a6062328c095337b4cadcefd1612348fdd5190b1dcbcb9b9e90bd8068
+          imagePullPolicy: IfNotPresent
+          args:
+            - patch
+            - --webhook-name=ingress-nginx-admission
+            - --namespace=$(POD_NAMESPACE)
+            - --patch-mutating=false
+            - --secret-name=ingress-nginx-admission
+            - --patch-failure-policy=Fail
+          env:
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+      restartPolicy: OnFailure
+      serviceAccountName: ingress-nginx-admission
+      nodeSelector:
+        kubernetes.io/os: linux
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 2000
+

--- a/infrastructure/utils.bash
+++ b/infrastructure/utils.bash
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+
+# exit codes: 
+#   0: success
+#   1: general error exit
+#   2: lockfile present
+
+set -o errexit
+set -o nounset
+set -o pipefail
+trap 'catch $? $LINENO' EXIT
+
+catch() {
+  __cleanup
+  if [ "$1" != "2" ]; then
+      __unlock
+  fi
+}
+
+: "${LOG_ERROR:=1}"
+: "${LOG_DEBUG:=1}"
+: "${LOG_INFO:=1}"
+: "${PROJECT:=project}"
+PROJECT_TMP=/tmp/$PROJECT
+
+function __cleanup() {
+    __msg_debug "Cleaning up"
+}
+
+__error_exit() {
+    line=$1
+    shift 1
+    __msg_error "non zero return code from line: $line — $*"
+    exit 1
+}
+
+__msg_error() {
+    { [[ "${LOG_ERROR}" == "1" ]] && echo -e "[ERROR]: $*"; } || true
+}
+
+__msg_debug() {
+    { [[ "${LOG_DEBUG}" == "1" ]] && echo -e "[DEBUG]: $*";} || true
+}
+
+__msg_info() {
+    { [[ "${LOG_INFO}" == "1" ]] && echo -e "[INFO]: $*"; } || true
+}
+
+__random_string() {
+    tr -dc A-Za-z0-9 </dev/urandom | head -c 13 ; echo ''
+}
+
+__lock() {
+    [ ! -f "$PROJECT_TMP/.$PROJECT.lock" ] || { __msg_error "Lockfile present at $PROJECT_TMP" && exit 2; }
+    __msg_info "Generating Lockfile at $PROJECT_TMP/.$PROJECT.lock"
+    mkdir -p "$PROJECT_TMP"
+    touch "$PROJECT_TMP/.$PROJECT.lock"
+}
+
+__unlock() {
+    __msg_info "Removing Lockfile"
+    rm "$PROJECT_TMP/.$PROJECT.lock" 2> /dev/null
+}
+
+__lock


### PR DESCRIPTION
Move the `infrastructure` dir from `cloud_infra` branch to `main` since these infra bringup scripts are common across deployment setups. Some cleanups have been made to make this possible. This will enhance the gitops workflow and reduce replications. 