### PR TITLE
Cloud infra fix cyclone config, server uri, and building map path

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,9 @@ This deployment is fully configurable and minimally will need following edits pr
 - RMF configuration in `rmf-deployment/`
     - `rmf_server_config.py` - replace DNS name `rmf-deployment-template.open-rmf.org` with your own.
     - `values.yaml` - replace registryUrl `ghcr.io/open-rmf` and DNS name `rmf-deployment-template.open-rmf.org` with your own.
-    - `cyclonedds.xml` - if you are using cyclonedds to communicate across multiple nodes on different machines, update the `Peers` in the `.xml`.
     - `rmf-site-modules.yaml` - Add site specific nodes (e.g. fleet and door adapters) to the template.
+    - `cyclonedds.xml` - if you are using cyclonedds to communicate across multiple nodes on different machines, update the `Peers` in the `.xml`.
+    - If you are using ros `galactic`, please switch the corresponding cyclonedds config path to `cyclonedds_galactic.xml`.
 
 ## Provisioning
 We will need the following resources:

--- a/rmf-deployment/cyclonedds.xml
+++ b/rmf-deployment/cyclonedds.xml
@@ -1,20 +1,15 @@
 <CycloneDDS xmlns="https://cdds.io/config" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="https://cdds.io/config https://raw.githubusercontent.com/eclipse-cyclonedds/cyclonedds/master/etc/cyclonedds.xsd">
         <Domain id="any">
                 <General>
-                        <Interfaces>
-                                <NetworkInterface name="cni0" priority="default" multicast="true"/> <!--Cluster network-->
-                                <!-- <NetworkInterface name="wg0" multicast="false"/> --> <!--Example interface for connecting remote devices over wireguard vpn-->
-                        </Interfaces>
+                        <NetworkInterfaceAddress>cni0</NetworkInterfaceAddress>
                         <AllowMulticast>default</AllowMulticast>
                         <MaxMessageSize>8192B</MaxMessageSize>
                         <Transport>udp</Transport>
                 </General>
                 <Discovery>
                         <Peers>
-                                <Peer address="10.8.0.1"/> <!-- wg instance -->
-                                <Peer address="10.8.0.4"/> <!-- rmf cluster instance -->
-                                <Peer address="10.8.0.14"/> <!-- temi instance -->
-                                <Peer address="10.8.0.16"/> <!-- gaussian test -->
+                                <Peer address="10.42.0.1"/>  <!-- rmf cluster instance -->
+                                <!-- <Peer address="10.42.0.2"/>  other instances -->
                         </Peers>
                         <ParticipantIndex>auto</ParticipantIndex>
                         <MaxAutoParticipantIndex>50</MaxAutoParticipantIndex>

--- a/rmf-deployment/cyclonedds_galactic.xml
+++ b/rmf-deployment/cyclonedds_galactic.xml
@@ -1,10 +1,7 @@
 <CycloneDDS xmlns="https://cdds.io/config" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="https://cdds.io/config https://raw.githubusercontent.com/eclipse-cyclonedds/cyclonedds/master/etc/cyclonedds.xsd">
         <Domain id="any">
                 <General>
-                        <Interfaces>
-                                <NetworkInterface name="cni0" priority="default" multicast="true"/> <!--Cluster network-->
-                                <!-- <NetworkInterface name="wg0" multicast="false"/> --> <!--Example interface for connecting remote devices over wireguard vpn-->
-                        </Interfaces>
+                        <NetworkInterfaceAddress>cni0</NetworkInterfaceAddress>
                         <AllowMulticast>default</AllowMulticast>
                         <MaxMessageSize>8192B</MaxMessageSize>
                         <Transport>udp</Transport>

--- a/rmf-deployment/templates/rmf-core-modules.yaml
+++ b/rmf-deployment/templates/rmf-core-modules.yaml
@@ -59,6 +59,8 @@ spec:
           value: {{ .Values.global.RMW_IMPLEMENTATION | quote }}
         - name: RMF_BIDDING_TIME_WINDOW
           value: {{ .Values.global.RMF_BIDDING_TIME_WINDOW | quote }}
+        - name: RMF_SERVER_URI
+          value: {{ .Values.global.RMF_SERVER_URI | quote }}
       command: ["/bin/bash"]
       args: 
        - -c

--- a/rmf-deployment/values.yaml
+++ b/rmf-deployment/values.yaml
@@ -15,6 +15,6 @@ global:
   RMF_USE_SIM_TIME: "false"
   RMF_BIDDING_TIME_WINDOW: "2.0"
   RMF_TRAJECTORY_VISUALIZER_LEVEL_NAME: "L1"
-  RMF_BUILDING_MAP_SERVER_CONFIG_PATH: "/opt/rmf/install/mysite_maps/share/maps/office/office.building.yaml"
+  RMF_BUILDING_MAP_SERVER_CONFIG_PATH: "/opt/rmf/install/mysite_maps/share/mysite_maps/office/office.building.yaml"
   RMF_FAILOVER_MODE: "false"
   RMF_SERVER_URI: "ws://localhost:8000/_internal"


### PR DESCRIPTION
- provide different cyclonedds config for `galactic` and `humble` due to breaking xml format change
  - `latest` tag uses `humble`, which uses the `cyclonedds.xml`
  - `galactic` tag uses the `cyclonedds_galactic.xml`
- include server_uri env to rmf dispatcher
- fix `rmf-site` building map path