### PR TITLE
add arg to use timestamp for task_id

### DIFF
--- a/rmf-deployment/templates/rmf-core-modules.yaml
+++ b/rmf-deployment/templates/rmf-core-modules.yaml
@@ -61,6 +61,8 @@ spec:
           value: {{ .Values.global.RMF_BIDDING_TIME_WINDOW | quote }}
         - name: RMF_SERVER_URI
           value: {{ .Values.global.RMF_SERVER_URI | quote }}
+        - name: RMF_TIMESTAMP_FOR_TASK_ID
+          value: {{ .Values.global.RMF_TIMESTAMP_FOR_TASK_ID | quote }}
       command: ["/bin/bash"]
       args: 
        - -c
@@ -70,6 +72,7 @@ spec:
         -p use_sim_time:=$(RMF_USE_SIM_TIME)
         -p bidding_time_window:=$(RMF_BIDDING_TIME_WINDOW)
         -p server_uri:=$(RMF_SERVER_URI)
+        -p use_timestamp_for_task_id:=$(RMF_TIMESTAMP_FOR_TASK_ID)
       volumeMounts:
         - mountPath: {{ .Values.global.DDS_CONFIG_MOUNTPATH | quote }}
           name: {{ .Values.global.DDS_CONFIG_VOLUME | quote }}

--- a/rmf-deployment/values.yaml
+++ b/rmf-deployment/values.yaml
@@ -18,3 +18,4 @@ global:
   RMF_BUILDING_MAP_SERVER_CONFIG_PATH: "/opt/rmf/install/mysite_maps/share/mysite_maps/office/office.building.yaml"
   RMF_FAILOVER_MODE: "false"
   RMF_SERVER_URI: "ws://localhost:8000/_internal"
+  RMF_TIMESTAMP_FOR_TASK_ID: "true"


### PR DESCRIPTION
Relevant to https://github.com/open-rmf/rmf_ros2/pull/223

Set the `RMF_TIMESTAMP_FOR_TASK_ID` as `true`. this will prevent task_id overwrite when restarting the dispatcher node in a deployment setup