### PR TITLE
builder-rosdep dockerfile improvements

### DIFF
--- a/rmf/builder-rosdep.Dockerfile
+++ b/rmf/builder-rosdep.Dockerfile
@@ -3,8 +3,13 @@ ARG ROS_DISTRO="humble"
 
 FROM $BASE_REGISTRY/ros:$ROS_DISTRO
 
-RUN apt update -y
-RUN apt install curl git wget -y
+RUN apt update && apt install -y \
+  cmake \
+  curl \
+  python3-pip \
+  git \
+  wget \
+  && rm -rf /var/lib/apt/lists/*
 
 RUN rm /etc/apt/sources.list.d/ros2-latest.list
 RUN curl -sSL https://raw.githubusercontent.com/ros/rosdistro/master/ros.key  -o /usr/share/keyrings/ros-archive-keyring.gpg
@@ -14,13 +19,18 @@ RUN echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/r
 RUN sh -c 'echo "deb http://packages.osrfoundation.org/gazebo/ubuntu-stable `lsb_release -cs` main" > /etc/apt/sources.list.d/gazebo-stable.list'
 RUN wget https://packages.osrfoundation.org/gazebo.key -O - | sudo apt-key add -
 
-RUN apt update && apt upgrade -y
-RUN apt install \
-    python3-pip cmake python3-colcon-common-extensions -y
+RUN apt update && apt install -y \
+  python3-colcon-common-extensions \
+  && apt-get upgrade -y \
+  && rm -rf /var/lib/apt/lists/*
 
 # download cyclonedds and use clang for humble
 RUN if [ "$ROS_DISTRO" = "humble" ]; then \
-        apt install ros-humble-rmw-cyclonedds-cpp -y && \
-        apt install clang-13 lldb-13 lld-13 -y && \
-        update-alternatives --install /usr/bin/c++ c++ /usr/bin/clang++-13 100; \
+      apt update && apt install -y \
+        clang-13 \
+        lldb-13 \
+        lld-13 \
+        ros-humble-rmw-cyclonedds-cpp \
+        && rm -rf /var/lib/apt/lists/* \
+      && update-alternatives --install /usr/bin/c++ c++ /usr/bin/clang++-13 100; \
     fi


### PR DESCRIPTION
## Bug fix

### Fixed bug

Dockerfiles are not using the recommended approach to use the apt installations as described in https://docs.docker.com/develop/develop-images/dockerfile_best-practices/.

### Fix applied

One liners for apt-get update + apt-get install together with clean up of `/var/lib/apt/lists/*` at the end.