### PR TITLE
Install pipenv via pip3

### DIFF
--- a/rmf-web/builder-rmf-web.Dockerfile
+++ b/rmf-web/builder-rmf-web.Dockerfile
@@ -10,6 +10,8 @@ COPY rmf-web-src src
 
 RUN apt-get update && apt-get install -y python3-venv
 
+RUN pip3 install pipenv
+
 RUN curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.37.2/install.sh | bash && \
   . $HOME/.nvm/nvm.sh && \
   nvm install 16


### PR DESCRIPTION
## Bug fix

### Fixed bug

Fix missing installation step `pipenv` for web builder.