### PR TITLE
Explicit quotes for strings in values.yaml

### DIFF
--- a/rmf-deployment/values.yaml
+++ b/rmf-deployment/values.yaml
@@ -1,20 +1,20 @@
 
 replicas: 1
-registryUrl: ghcr.io/open-rmf
-builder_ns: ghcr.io/open-rmf/rmf_deployment_template
-hostName: rmf-deployment-template.open-rmf.org
+registryUrl: 'ghcr.io/open-rmf'
+builder_ns: 'ghcr.io/open-rmf/rmf_deployment_template'
+hostName: 'rmf-deployment-template.open-rmf.org'
 
 global:
-  ROS_DOMAIN_ID: 15
-  DDS_CONFIG_MOUNTPATH: /etc/cyclonedds
-  DDS_CONFIG_VOLUME: cyclonedds-configmap
-  DDS_ENV: CYCLONEDDS_URI
-  DDS_CONFIG: /etc/cyclonedds/cyclonedds.xml
-  RMW_IMPLEMENTATION: rmw_cyclonedds_cpp
+  ROS_DOMAIN_ID: '15'
+  DDS_CONFIG_MOUNTPATH: '/etc/cyclonedds'
+  DDS_CONFIG_VOLUME: 'cyclonedds-configmap'
+  DDS_ENV: 'CYCLONEDDS_URI'
+  DDS_CONFIG: /etc/cyclonedds/cyclonedds.xml'
+  RMW_IMPLEMENTATION: 'rmw_cyclonedds_cpp'
 
-  RMF_USE_SIM_TIME: "false"
-  RMF_BIDDING_TIME_WINDOW: "2.0"
-  RMF_TRAJECTORY_VISUALIZER_LEVEL_NAME: "L1"
-  RMF_BUILDING_MAP_SERVER_CONFIG_PATH: "/opt/rmf/install/mysite_maps/share/mysite_maps/office/office.building.yaml"
-  RMF_FAILOVER_MODE: "false"
-  RMF_SERVER_URI: "ws://localhost:8000/_internal"
+  RMF_USE_SIM_TIME: 'false'
+  RMF_BIDDING_TIME_WINDOW: '2.0'
+  RMF_TRAJECTORY_VISUALIZER_LEVEL_NAME: 'L1'
+  RMF_BUILDING_MAP_SERVER_CONFIG_PATH: '/opt/rmf/install/mysite_maps/share/mysite_maps/office/office.building.yaml'
+  RMF_FAILOVER_MODE: 'false'
+  RMF_SERVER_URI: 'ws://localhost:8000/_internal'


### PR DESCRIPTION
Following the [suggestions of best practices](https://helm.sh/docs/chart_best_practices/values/#make-types-clear) in Helm Chart page, the PR makes the string in `values.yaml` explicit by adding quotes. Single quotes preferred since there is no special character that needs to be interpreted.