### PR TITLE
Remove sed command that removes python version dependency

### DIFF
--- a/rmf-web/builder-rmf-web.Dockerfile
+++ b/rmf-web/builder-rmf-web.Dockerfile
@@ -25,7 +25,6 @@ RUN curl -fsSL https://get.pnpm.io/install.sh | bash - && \
   pnpm env use --global 16
 
 RUN cd /opt/rmf/src/rmf-web &&  \
-  sed -i '$ d' Pipfile && \
   pnpm config set unsafe-perm && \
   pnpm install
 


### PR DESCRIPTION
## Bug fix

### Fixed bug

<!-- Briefly describe the bug being fixed.
If there is a bug report issue for the bug, link to that issue.
If there is not a bug report issue for the bug, create one first and fill out all the required information there, then link to that issue from this bug fix pull request. -->

Fixed build issue where api-server python dependencies were out-of-date, when the required python version is removed.

This was due to an old workaround where the python version dependency line was removed from the `Pipfile`.