### PR TITLE
Update keycloak to latest version 22.0.1

### DIFF
--- a/rmf-deployment/templates/keycloak.yaml
+++ b/rmf-deployment/templates/keycloak.yaml
@@ -111,7 +111,8 @@ spec:
         - name: keycloak
           image: quay.io/keycloak/keycloak:22.0.1
           # --optimized flag fails with postgre https://github.com/keycloak/keycloak/issues/15898
-          args: ["start", "--log-level=DEBUG", "--http-relative-path=/auth"]
+          # --log-level=DEBUG can be added for debugging
+          args: ["start", "--http-relative-path=/auth"]
           imagePullPolicy: IfNotPresent
           env:
             - name: KEYCLOAK_ADMIN

--- a/rmf-deployment/templates/keycloak.yaml
+++ b/rmf-deployment/templates/keycloak.yaml
@@ -109,31 +109,35 @@ spec:
     spec:
       containers:
         - name: keycloak
-          image: quay.io/keycloak/keycloak:12.0.4
+          image: quay.io/keycloak/keycloak:22.0.1
+          # --optimized flag fails with postgre https://github.com/keycloak/keycloak/issues/15898
+          args: ["start", "--log-level=DEBUG", "--http-relative-path=/auth"]
           imagePullPolicy: IfNotPresent
           env:
-            - name: KEYCLOAK_USER
+            - name: KEYCLOAK_ADMIN
               valueFrom:
                 secretKeyRef:
                   name: keycloak-secret
                   key: KEYCLOAK_USER
-            - name: KEYCLOAK_PASSWORD
+            - name: KEYCLOAK_ADMIN_PASSWORD
               valueFrom:
                 secretKeyRef:
                   name: keycloak-secret
                   key: KEYCLOAK_PASSWORD
-            - name: PROXY_ADDRESS_FORWARDING
-              value: 'true'
-            - name: DB_VENDOR
+            - name: KC_PROXY
+              value: "edge"
+            - name: KC_HOSTNAME
+              value: {{ .Values.hostName | quote }}
+            - name: KC_DB
               value: postgres
-            - name: DB_ADDR
-              value: keycloak-db
-            - name: DB_USER
+            - name: KC_DB_URL
+              value: jdbc:postgresql://keycloak-db/keycloak
+            - name: KC_DB_USERNAME
               valueFrom:
                 secretKeyRef:
                   name: keycloak-secret
                   key: DB_USER
-            - name: DB_PASSWORD
+            - name: KC_DB_PASSWORD
               valueFrom:
                 secretKeyRef:
                   name: keycloak-secret
@@ -146,7 +150,10 @@ spec:
           readinessProbe:
             httpGet:
               path: /auth/realms/master
-              port: 8080
+              port: http
+            initialDelaySeconds: 30
+            timeoutSeconds: 1
+
 
 ---
 apiVersion: networking.k8s.io/v1

--- a/rmf-deployment/values.yaml
+++ b/rmf-deployment/values.yaml
@@ -2,7 +2,7 @@
 replicas: 1
 registryUrl: ghcr.io/open-rmf
 builder_ns: ghcr.io/open-rmf/rmf_deployment_template
-hostName: localhost
+hostName: rmf-deployment-template.open-rmf.org
 
 global:
   ROS_DOMAIN_ID: 15

--- a/rmf-deployment/values.yaml
+++ b/rmf-deployment/values.yaml
@@ -2,7 +2,7 @@
 replicas: 1
 registryUrl: ghcr.io/open-rmf
 builder_ns: ghcr.io/open-rmf/rmf_deployment_template
-hostName: rmf-deployment-template.open-rmf.org
+hostName: localhost
 
 global:
   ROS_DOMAIN_ID: 15


### PR DESCRIPTION
## New feature implementation

### Implemented feature

Bump version of keycloak to latest 22.0.1

### Implementation description

Starting from version 17, keycloak migrated to something called Quarkus (java container env) and all the configuration seems to be completely different now. Hence the current configuration in the chart is no good anymore. There is an ENTRYPOINT now called `kc.sh` that acts as a wrapper and the chart needs to pass arguments to it (particularly "start"). This was the reason for the error log displayed in the pod under the status of CrashLoopBackOff if we tried to bump the version without making more changes.

Possible issues: I've seen the `keycloak` pod to fail to connect to the `keycloak-db` when I run the installation for the first time and the problem gone after reloading the `keycloak` pod. Might be a race condition problem, still need to dig into it to be sure. @akash-roboticist commented: "As for the keycloak initial failure, perhaps we can tackle it in another PR as it doesnt sound breaking to me? FWIW, Keycloak does need some time to start up and serve requests."

![Screenshot from 2023-08-02 17-49-22](https://github.com/j-rivero/rmf_deployment_template/assets/2098802/d169e0b2-e6fe-4135-8215-ecafcd5beab8)
![Screenshot from 2023-08-02 17-49-37](https://github.com/j-rivero/rmf_deployment_template/assets/2098802/7de81d90-7f7b-4b28-9b2e-441ddedaf40a)