### PR TITLE
Increase memory allocation for build

### DIFF
--- a/rmf-web/rmf-web-dashboard.Dockerfile
+++ b/rmf-web/rmf-web-dashboard.Dockerfile
@@ -33,6 +33,8 @@ RUN echo "DOMAIN_URL: $DOMAIN_URL"\
     && echo "REACT_APP_AUTH_PROVIDER: $REACT_APP_AUTH_PROVIDER"\
     && echo "REACT_APP_KEYCLOAK_CONFIG: $REACT_APP_KEYCLOAK_CONFIG"
 
+ENV NODE_OPTIONS "--max_old_space_size=4096"
+
 RUN cd /opt/rmf/src/rmf-web/packages/dashboard && \
   pnpm run --filter rmf-dashboard... build
 


### PR DESCRIPTION
## Bug fix

### Fixed bug

This is required for https://github.com/open-rmf/rmf-web/pull/775 to build the dashboard.

<!-- Briefly describe the bug being fixed.
If there is a bug report issue for the bug, link to that issue.
If there is not a bug report issue for the bug, create one first and fill out all the required information there, then link to that issue from this bug fix pull request. -->

### Fix applied

<!-- Describe in detail the approach taken, tools used, etc. to identify the cause of the bug and what was done to fix it. -->

Increased memory allocation for build to 4096 MB, instead of the default 512 MB.