### PR TITLE
Fix pnpm install at build error

### DIFF
--- a/dockerfiles/rmf-web/api-server/Dockerfile
+++ b/dockerfiles/rmf-web/api-server/Dockerfile
@@ -50,7 +50,7 @@ RUN mkdir -p /ws \
 
 # build api-server
 RUN cd /ws \
-  && pnpm install -w --filter api-server...
+  && pnpm install -w --no-frozen-lockfile --filter api-server...
 
 FROM docker.io/library/ros:$ROS_DISTRO-ros-core
 

--- a/dockerfiles/rmf-web/dashboard/Dockerfile
+++ b/dockerfiles/rmf-web/dashboard/Dockerfile
@@ -23,7 +23,7 @@ RUN mkdir -p /ws \
 
 # install deps
 RUN cd /ws \
-  && pnpm install --filter rmf-dashboard-framework...
+  && pnpm install --no-frozen-lockfile --filter rmf-dashboard-framework...
 
 # copy in the dashboard main files
 RUN mkdir -p /ws/packages/rmf-dashboard-framework/examples/target


### PR DESCRIPTION
https://github.com/open-rmf/rmf_deployment_template/actions/runs/13106714946/job/37000806558#step:4:1278

## Bug fix

### Fixed bug
Fix pnpm install at build error 
```
#13 0.382  ERR_PNPM_LOCKFILE_CONFIG_MISMATCH  Cannot proceed with the frozen installation. The current "patchedDependencies" configuration doesn't match the value found in the lockfile
#13 0.382 
#13 0.382 Update your lockfile using "pnpm install --no-frozen-lockfile"
```
- https://github.com/open-rmf/rmf_deployment_template/actions/runs/13106714946/job/37000806558#step:4:1278
- https://github.com/open-rmf/rmf_deployment_template/actions/runs/13106714946/job/37000806254#step:4:1285
- https://github.com/open-rmf/rmf_deployment_template/actions/runs/13106714946/job/37000806558#step:4:1278

### Fix applied
Updated pnpm install lines in dockerfiles with added flag `--no-frozen-lockfile`
